### PR TITLE
Fix race condition while registering new metric

### DIFF
--- a/src/hay_metrics.erl
+++ b/src/hay_metrics.erl
@@ -115,8 +115,8 @@ register_if_not_exist(Type, Key) ->
         {error, nonexistent_metric} ->
             case register_(Type, Key) of
                 %% Avoid race condition errors with
-                %% processes tried to push with the same key
-                %% at the sane time, when key is not yet registered
+                %% processes tries to push with the same key
+                %% at the same time, when key is not yet registered
                 {error, _, metric_already_exists} ->
                     ok;
                 Error -> Error

--- a/src/hay_metrics.erl
+++ b/src/hay_metrics.erl
@@ -108,6 +108,7 @@ construct_key([Head | Tail], Acc) ->
 construct_key(NonList, Acc) ->
     <<Acc/binary, ?SEPARATOR, (construct_key(NonList))/binary>>.
 
+-spec register_if_not_exist(metric_type(), metric_key()) -> ok | {error, register_error()}.
 register_if_not_exist(Type, Key) ->
     case check_metric_exist(Type, Key) of
         ok ->
@@ -119,15 +120,14 @@ register_if_not_exist(Type, Key) ->
                 %% at the same time, when key is not yet registered
                 {error, _, metric_already_exists} ->
                     ok;
-                Error -> Error
+                Error ->
+                    Error
             end;
         {error, {wrong_type, OtherType}} ->
             % already registered with other type
             {error, {already_registered, Key, Type, OtherType}}
     end.
 
--spec register_(metric_type(), metric_key()) ->
-    ok | {error, register_error()}.
 register_(counter, Key) ->
     folsom_metrics:new_counter(Key);
 register_(gauge, Key) ->


### PR DESCRIPTION
Словили вот такое:
```
[1055655586194022400 1055655586198216704 1055655586261155840][client] internal error call service error error:{badmatch,{error,<<"woody.client.hackney_pool.woody_automaton.no_socket">>,metric_already_exists}}
in hay_metrics:push/1 at line 75
	in hackney_connect:socket_from_pool/4 at line 231
	in hackney_connect:connect/5 at line 47
	in hackney:request/5 at line 333
	in woody_client_thrift_http_transport:send/5 at line 116
	in woody_client_thrift_http_transport:flush/1 at line 89
	in thrift_transport:flush/1 at line 121
	in thrift_binary_protocol:flush_transport/1 at line 64
```
Судя по коду, такое возможно если два (или более) процесса пошли писать по одном ключу, которого в `folsom`, ещё нет, и ушли в ветку регистрации этого ключа.