### PR TITLE
MSPF-579: Prometheus collector

### DIFF
--- a/include/how_are_you.hrl
+++ b/include/how_are_you.hrl
@@ -1,0 +1,11 @@
+-ifndef(how_are_you_included__).
+-define(how_are_you_included__, true).
+
+%% struct 'metric'
+-record(metric, {
+    type    :: how_are_you:metric_type(),
+    key     :: how_are_you:metric_key(),
+    value   :: how_are_you:metric_value()
+}).
+
+-endif.

--- a/rebar.config
+++ b/rebar.config
@@ -29,7 +29,9 @@
 % Common project dependencies.
 {deps, [
     {folsom        , {git, "https://github.com/folsom-project/folsom.git"         , {branch, "master"}}},
-    {cg_mon        , {git, "https://github.com/rbkmoney/cg_mon.git"               , {branch, "master"}}}
+    {cg_mon        , {git, "https://github.com/rbkmoney/cg_mon.git"               , {branch, "master"}}},
+    {prometheus, "4.6.0"},
+    {prometheus_cowboy, "0.1.8"}
 ]}.
 
 {xref_checks, [

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,5 +1,6 @@
-{"1.1.0",
-[{<<"bear">>,{pkg,<<"bear">>,<<"0.8.7">>},1},
+{"1.2.0",
+[{<<"accept">>,{pkg,<<"accept">>,<<"0.3.5">>},2},
+ {<<"bear">>,{pkg,<<"bear">>,<<"0.8.7">>},1},
  {<<"cg_mon">>,
   {git,"https://github.com/rbkmoney/cg_mon.git",
        {ref,"5a87a37694e42b6592d3b4164ae54e0e87e24e18"}},
@@ -7,8 +8,21 @@
  {<<"folsom">>,
   {git,"https://github.com/folsom-project/folsom.git",
        {ref,"eeb1cc467eb64bd94075b95b8963e80d8b4df3df"}},
-  0}]}.
+  0},
+ {<<"prometheus">>,{pkg,<<"prometheus">>,<<"4.6.0">>},0},
+ {<<"prometheus_cowboy">>,{pkg,<<"prometheus_cowboy">>,<<"0.1.8">>},0},
+ {<<"prometheus_httpd">>,{pkg,<<"prometheus_httpd">>,<<"2.1.11">>},1}]}.
 [
 {pkg_hash,[
- {<<"bear">>, <<"16264309AE5D005D03718A5C82641FCC259C9E8F09ADEB6FD79CA4271168656F">>}]}
+ {<<"accept">>, <<"B33B127ABCA7CC948BBE6CAA4C263369ABF1347CFA9D8E699C6D214660F10CD1">>},
+ {<<"bear">>, <<"16264309AE5D005D03718A5C82641FCC259C9E8F09ADEB6FD79CA4271168656F">>},
+ {<<"prometheus">>, <<"20510F381DB1CCAB818B4CF2FAC5FA6AB5CC91BC364A154399901C001465F46F">>},
+ {<<"prometheus_cowboy">>, <<"CFCE0BC7B668C5096639084FCD873826E6220EA714BF60A716F5BD080EF2A99C">>},
+ {<<"prometheus_httpd">>, <<"F616ED9B85B536B195D94104063025A91F904A4CFC20255363F49A197D96C896">>}]},
+{pkg_hash_ext,[
+ {<<"accept">>, <<"11B18C220BCC2EAB63B5470C038EF10EB6783BCB1FCDB11AA4137DEFA5AC1BB8">>},
+ {<<"bear">>, <<"534217DCE6A719D59E54FB0EB7A367900DBFC5F85757E8C1F94269DF383F6D9B">>},
+ {<<"prometheus">>, <<"4905FD2992F8038ECCD7AA0CD22F40637ED618C0BED1F75C05AACEC15B7545DE">>},
+ {<<"prometheus_cowboy">>, <<"BA286BECA9302618418892D37BCD5DC669A6CC001F4EB6D6AF85FF81F3F4F34C">>},
+ {<<"prometheus_httpd">>, <<"0BBE831452CFDF9588538EB2F570B26F30C348ADAE5E95A7D87F35A5910BCF92">>}]}
 ].

--- a/src/hay_metrics.erl
+++ b/src/hay_metrics.erl
@@ -10,11 +10,7 @@
 -export([get/0]).
 -export([fold/2]).
 
--record(metric, {
-    type    :: metric_type(),
-    key     :: metric_key(),
-    value   :: metric_value()
-}).
+-include_lib("how_are_you/include/how_are_you.hrl").
 
 -opaque metric() :: #metric{}.
 -type metric_type() :: counter | gauge.

--- a/src/hay_prometheus_collector.erl
+++ b/src/hay_prometheus_collector.erl
@@ -1,0 +1,43 @@
+-module(hay_prometheus_collector).
+
+-behaviour(prometheus_collector).
+
+-export([deregister_cleanup/1]).
+-export([collect_mf/2]).
+
+-import(prometheus_model_helpers, [create_mf/4]).
+
+-include_lib("how_are_you/include/how_are_you.hrl").
+
+%% ===================================================================
+%% API
+%% ===================================================================
+
+%% called to collect Metric Families
+-spec collect_mf(_, _) -> _.
+collect_mf(Registry, Callback) ->
+  case registry() of
+    Registry -> 
+      Metrics = metrics(),
+      [add_metric_family(Metric, Callback) || Metric <- Metrics],
+      ok;
+    _ ->
+      ok
+  end.
+
+add_metric_family(#metric{type = Type, key = Key, value = Value}, Callback) ->
+  Callback(create_mf(Key, Key, Type, Value)).
+
+%% called when collector deregistered
+-spec deregister_cleanup(_) -> ok.
+deregister_cleanup(_Registry) -> ok.
+
+metrics() ->
+    % note: some of this metrics could be collected by prometheus default collectors
+    hay_vm_handler:gather_metrics(ok) ++ hay_cgroup_handler:gather_metrics(ok). % TODO: configuration?
+
+registry() ->
+  case application:get_env(how_are_you, registry) of
+    {ok, Registy} -> Registy;
+    _ -> default
+  end.

--- a/src/hay_prometheus_collector.erl
+++ b/src/hay_prometheus_collector.erl
@@ -16,17 +16,17 @@
 %% called to collect Metric Families
 -spec collect_mf(_, _) -> _.
 collect_mf(Registry, Callback) ->
-  case registry() of
-    Registry -> 
-      Metrics = metrics(),
-      [add_metric_family(Metric, Callback) || Metric <- Metrics],
-      ok;
+    case registry() of
+        Registry -> 
+        Metrics = metrics(),
+        [add_metric_family(Metric, Callback) || Metric <- Metrics],
+        ok;
     _ ->
-      ok
+        ok
   end.
 
 add_metric_family(#metric{type = Type, key = Key, value = Value}, Callback) ->
-  Callback(create_mf(Key, Key, Type, Value)).
+    Callback(create_mf(Key, Key, Type, Value)).
 
 %% called when collector deregistered
 -spec deregister_cleanup(_) -> ok.
@@ -37,7 +37,7 @@ metrics() ->
     hay_vm_handler:gather_metrics(ok) ++ hay_cgroup_handler:gather_metrics(ok). % TODO: configuration?
 
 registry() ->
-  case application:get_env(how_are_you, registry) of
-    {ok, Registy} -> Registy;
-    _ -> default
-  end.
+    case application:get_env(how_are_you, registry) of
+        {ok, Registy} -> Registy;
+        _ -> default
+    end.

--- a/src/hay_prometheus_publisher.erl
+++ b/src/hay_prometheus_publisher.erl
@@ -1,0 +1,8 @@
+-module(hay_prometheus_publisher).
+
+-export([get_route/0]).
+
+-spec get_route() ->
+    {iodata(), module(), []}.
+get_route() ->
+    {"/metrics/[:registry]", prometheus_cowboy2_handler, []}.

--- a/src/how_are_you.app.src
+++ b/src/how_are_you.app.src
@@ -10,7 +10,9 @@
         stdlib,
         os_mon,
         cg_mon,
-        folsom
+        folsom,
+        prometheus,
+        prometheus_cowboy
     ]},
     {env, []},
     {modules, []},

--- a/src/how_are_you.erl
+++ b/src/how_are_you.erl
@@ -13,6 +13,7 @@
 -export([metric_construct/3]).
 -export([metric_register/1]).
 -export([metric_push/1]).
+-export([get_metrics_route/0]).
 
 %% Supervisor callbacks
 -export([init/1]).
@@ -96,3 +97,9 @@ start(_StartType, _StartArgs) ->
     ok.
 stop(_State) ->
     ok.
+
+
+-spec get_metrics_route() ->
+    {iodata(), module(), []}.
+get_metrics_route() ->
+    {"/metrics/[:registry]", prometheus_cowboy2_handler, []}.

--- a/src/how_are_you.erl
+++ b/src/how_are_you.erl
@@ -97,9 +97,3 @@ start(_StartType, _StartArgs) ->
     ok.
 stop(_State) ->
     ok.
-
-
--spec get_metrics_route() ->
-    {iodata(), module(), []}.
-get_metrics_route() ->
-    {"/metrics/[:registry]", prometheus_cowboy2_handler, []}.


### PR DESCRIPTION
Альтернативная #17 попытка максимально просто добавить поддержку экспорта метрик в `prometheus text format`.

В данном случае метрики собираются по вызову хэндлера и расчет сделан на то, что у нас есть контроль над тем, как часто этот хэндлер будет дергаться